### PR TITLE
Develop

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,9 +24,10 @@ lazy val commonSettings = Seq(
     "Typesafe Snapshots" at "http://repo.typesafe.com/typesafe/snapshots/"
   ),
 libraryDependencies ++= Seq(
+  "javax.persistence" % "persistence-api" % "1.0.2",
   "com.tinkerpop.blueprints" % "blueprints-core" % "2.6.0",
-  "com.orientechnologies" % "orientdb-core" % "2.1.8",
-  "com.orientechnologies" % "orientdb-graphdb" % "2.1.8",
+  "com.orientechnologies" % "orientdb-core" % "2.2.5",
+  "com.orientechnologies" % "orientdb-graphdb" % "2.2.5",
   "org.scala-lang" % "scalap" % "2.11.8", //TODO fix scala dep on scalaVersion
   //"jline" % "jline" % "2.12.1",
   "jline" % "jline" % "0.9.94",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,3 +13,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.1")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
 
 //addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")

--- a/src/main/scala/com/emotioncity/soriento/RichODatabaseDocumentImpl.scala
+++ b/src/main/scala/com/emotioncity/soriento/RichODatabaseDocumentImpl.scala
@@ -65,11 +65,11 @@ object RichODatabaseDocumentImpl {
       //println("ThreadLocal is: " + instance.getClass.getName)
       Future {
         val internalDb = if (isPooled) {
-          val tempDb = db.asInstanceOf[ODatabaseDocumentTx]
-          tempDb.activateOnCurrentThread()
+          db.asInstanceOf[ODatabaseDocumentTx]
         } else {
           instance.asInstanceOf[ODatabaseDocumentTx].copy()
         }
+        internalDb.activateOnCurrentThread()
         blocking {
           payload(internalDb)
         }

--- a/src/main/scala/com/emotioncity/soriento/loadbyname/AnyRichODatabaseDocumentImpl.scala
+++ b/src/main/scala/com/emotioncity/soriento/loadbyname/AnyRichODatabaseDocumentImpl.scala
@@ -28,6 +28,7 @@ object AnyRichODatabaseDocumentImpl {
       */
     def queryAnyBySql[T <: Any](query: String)(implicit reader: ODocumentReader[Any]): Seq[T] = blockingCall { db =>
       val results: java.util.List[ODocument] = db.query(new OSQLSynchQuery[ODocument](query))
+      //val constraint = scala.reflect.runtime.universe.typeOf[T]
       val objs: Seq[Any] = results.asScala.map(document => reader.read(document))
       objs.asInstanceOf[Seq[T]]
     }

--- a/src/main/scala/com/emotioncity/soriento/loadbyname/ClassNameReadersRegistry.scala
+++ b/src/main/scala/com/emotioncity/soriento/loadbyname/ClassNameReadersRegistry.scala
@@ -55,7 +55,7 @@ case class DocumentReadConstructException(override val doc: ODocument,
       }
 
       val expectedType = if (i>=cparams.size) "xxx" else cparams(i).typeSignature.toString
-      f" ${i}%3d ${paramName}%-15s ${paramString}%40s : ${foundType}%-30s   ${expectedType}\n"
+      f" ${i}%3d ${paramName}%15s ${paramString}%40s : ${foundType}%-30s   ${expectedType}\n"
     }
 
 
@@ -64,7 +64,7 @@ case class DocumentReadConstructException(override val doc: ODocument,
       params: ${params.mkString(",")}
          tpe: ${tpe}
          doc: ${doc}
-PARAM                                                   VALUE : SUPPLIED TYPE                  CONSTRUCTOR EXPECTED TYPE
+PARAM |         NAME |                              DOC VALUE | DOC VALUE TYPE                 | CONSTRUCTOR EXPECTED TYPE
 ${table.mkString("")}
 ${super.getMessage}
 """

--- a/src/test/scala/com/emotioncity/soriento/loadbyname/PolymorphicLoadByNameTest.scala
+++ b/src/test/scala/com/emotioncity/soriento/loadbyname/PolymorphicLoadByNameTest.scala
@@ -164,6 +164,7 @@ class PolymorphicLoadByNameTest extends FunSuite with Matchers with BeforeAndAft
 
     implicit val typeReaders = ClassNameReadersRegistry()
     typeReaders.add[AllTypeFields]
+    typeReaders.add[Sub]  // Register polymorphic
 
     val dsl = new Dsl {}
 
@@ -183,6 +184,8 @@ class PolymorphicLoadByNameTest extends FunSuite with Matchers with BeforeAndAft
   test("Allow null object field") {
     implicit val typeReaders = ClassNameReadersRegistry()
     typeReaders.add[AllTypeFields]
+    typeReaders.add[Sub]  // Register polymorphic
+
     val dsl = new Dsl {}
     val doc = dsl.productToDocument(AllTypeFields())
     doc.field("string", null.asInstanceOf[String])  // Should be able to load null into an object field.
@@ -195,6 +198,7 @@ class PolymorphicLoadByNameTest extends FunSuite with Matchers with BeforeAndAft
 
     implicit val typeReaders = ClassNameReadersRegistry()
     typeReaders.add[AllTypeFields]
+    typeReaders.add[Sub]  // Register polymorphic
 
     val dsl = new Dsl {}
 
@@ -234,6 +238,8 @@ class PolymorphicLoadByNameTest extends FunSuite with Matchers with BeforeAndAft
       val odb = new ODb {}
       val oclass: OClass = odb.createOClass[AllTypeFields]
       odb.createOClass[Thing]
+      val supers = List(odb.createOClass[Super])
+      odb.createOClass[Sub].setSuperClasses(supers.asJava)
 
       // Default mapping for enums is to INTEGER
       oclass.getProperty("e").getType() should be(OType.INTEGER)
@@ -261,6 +267,7 @@ class PolymorphicLoadByNameTest extends FunSuite with Matchers with BeforeAndAft
 
       implicit val typeReaders = ClassNameReadersRegistry()
       typeReaders.add[AllTypeFields]
+      typeReaders.add[Sub]
 
       import AnyRichODatabaseDocumentImpl._
 

--- a/src/test/scala/com/emotioncity/soriento/loadbyname/PolymorphicLoadByNameTest.scala
+++ b/src/test/scala/com/emotioncity/soriento/loadbyname/PolymorphicLoadByNameTest.scala
@@ -210,6 +210,25 @@ class PolymorphicLoadByNameTest extends FunSuite with Matchers with BeforeAndAft
     }
   }
 
+  // FAILING
+  /*
+  test("Basic type result") {
+    withDropDB(makeTestDB()) { implicit db: ODatabaseDocumentTx =>
+      val odb = new ODb {}
+      odb.createOClass[AllTypeFields]
+      db.save(AllTypeFields())
+
+      val result = db.query[java.util.List[ODocument]](new OSQLSynchQuery[ODocument]("select string from AllTypeFields").setFetchPlan("*:-1"))
+      println( result.toArray()(0).getClass )
+      //should be (AllTypeFields().string)
+      val dsl = new Dsl {}
+      implicit val typeReaders = ClassNameReadersRegistry()
+      import AnyRichODatabaseDocumentImpl._
+      val result2 = db.queryAnyBySql[AllTypeFields]("select string from AllTypeFields;")
+    }
+  }
+  */
+
   test("All type fields") {
     withDropDB(makeTestDB()) { implicit db: ODatabaseDocumentTx =>
       val odb = new ODb {}

--- a/src/test/scala/com/emotioncity/soriento/loadbyname/PolymorphicLoadByNameTest.scala
+++ b/src/test/scala/com/emotioncity/soriento/loadbyname/PolymorphicLoadByNameTest.scala
@@ -160,6 +160,26 @@ class PolymorphicLoadByNameTest extends FunSuite with Matchers with BeforeAndAft
   }
 
 
+  test("Exception on unconstructable") {
+
+    implicit val typeReaders = ClassNameReadersRegistry()
+    typeReaders.add[AllTypeFields]
+
+    val dsl = new Dsl {}
+
+    val doc = dsl.productToDocument(AllTypeFields())
+    doc.field("i", 2.0)  // double were int is expected
+
+    try {
+      val obj2 = typeReaders.read(doc)
+    }
+    catch {
+      case e:DocumentReadConstructException => {
+        println(e.getMessage)
+      }
+    }
+  }
+
 
   test("All type fields") {
     withDropDB(makeTestDB()) { implicit db: ODatabaseDocumentTx =>

--- a/src/test/scala/com/emotioncity/soriento/testmodels/AllTypeFields.scala
+++ b/src/test/scala/com/emotioncity/soriento/testmodels/AllTypeFields.scala
@@ -21,6 +21,7 @@ case class AllTypeFields(
                           val f: Float = 1.0f,
                           val d: Double = 1.0,
                           val b: Byte = 1,
+                          val string:String = "beebop",
                           val e: WeekdayEnum = MON, // scala.Enumeration
 
                           // List of builtin types not working.

--- a/src/test/scala/com/emotioncity/soriento/testmodels/AllTypeFields.scala
+++ b/src/test/scala/com/emotioncity/soriento/testmodels/AllTypeFields.scala
@@ -11,6 +11,11 @@ import scala.collection.mutable.ArrayBuffer
 
 case class Thing(x:Int)
 
+trait Super
+
+case class Sub(x:Int = 123) extends Super
+
+
 /**
   * Created by sir on 5/10/16.
   */
@@ -32,6 +37,8 @@ case class AllTypeFields(
                           //                          val iOpt: Option[Int] = Some(123),
 
                           val obj:Thing = new Thing(123),
+                          val stringISeq:IndexedSeq[String] = IndexedSeq("123","456"),
+                          val intISeq:IndexedSeq[Int] = IndexedSeq(123),
                           val objISeq:IndexedSeq[Thing] = IndexedSeq(Thing(1), Thing(2)),
                           val objSeq:Seq[Thing] = Seq(Thing(1), Thing(2)),
                           val objMutISeq:collection.mutable.IndexedSeq[Thing] = ArrayBuffer(Thing(1), Thing(2)),
@@ -40,10 +47,18 @@ case class AllTypeFields(
                           val objImMutISeq:collection.immutable.Seq[Thing] = collection.immutable.IndexedSeq(Thing(1), Thing(2)),
                           val objArray:Array[Thing] = Array(Thing(1), Thing(2)),
 
+                          //val intArray:Array[Int] = Array(1,2), // Fails
+                          //val stringArray:Array[String] = Array("1","2"), // Works but need to fix test to compare array fields
+
                           //FAILING val iOptOpt: Option[Option[Int]] = Some(Some(123)),
                           val eOpt: Option[WeekdayEnum] = Some(MON),
                           //FAILING val eOptOpt: Option[Option[WeekdayEnum]] = Some(Some(MON)),
-                          @Id id: Option[ORID] = None
+                          @Id id: Option[ORID] = None,
+
+                          // Polymorphic members
+                          val sub:Super = Sub(123),
+                          val subList:List[Super] = List(Sub(123)),
+                          val subSeq:Seq[Super] = Seq(Sub(123))
                         ){
   def withNullIDs() = this.copy(id=None)
 }


### PR DESCRIPTION
Bumped up supported OrientDb version to 2.2.5. 
Added javax.persistence 1.0.2 to dependencies since it was deleted from OrientDb dependencies. 
Added sbt-dependency-graph plugin to analyze project dependency better. 
Fixed activation of database for threads when queries are async.
