### PR TITLE
removed println() from EnumReflector.memberNameToEnumValue()

### DIFF
--- a/src/main/scala/com/emotioncity/soriento/EnumReflector.scala
+++ b/src/main/scala/com/emotioncity/soriento/EnumReflector.scala
@@ -72,7 +72,7 @@ class EnumReflector(val enumElementType: Type) {
       .map { s =>
         val memberName = s.name.toString
         val enumValue = enumObject.getClass.getMethod(memberName).invoke(enumObject).asInstanceOf[scala.Enumeration$Value]
-        println(s"${memberName} ${enumValue}")
+//        println(s"${memberName} ${enumValue}")
         (memberName -> enumValue)
       }: _*
   )


### PR DESCRIPTION
Hello

Please accept this little pull request to remove verbose unneeded printing.
